### PR TITLE
Add hadolint Dockerfile linter

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -247,6 +247,28 @@ export const linters = {
         "message": 3
       }
     ]
+  },
+
+  "hadolint": {
+    "command": "hadolint",
+    "sourceName": "hadolint",
+    "args": [
+      "-f",
+      "json",
+      "-"
+    ],
+    "parseJson": {
+      "line": "line",
+      "column": "column",
+      "security": "level",
+      "message": "${message} [${code}]"
+    },
+    "securities": {
+      "error": "error",
+      "warning": "warning",
+      "info": "info",
+      "style": "hint"
+    }
   }
 }
 


### PR DESCRIPTION
This adds [hadolint](https://github.com/hadolint/hadolint/) to be used as a Dockerfile linter.

I already added this to the Linters wiki: https://github.com/iamcco/diagnostic-languageserver/wiki/Linters/361937f4f7d814eef9504d5995ea82a4aae56715#hadolint