### PR TITLE
Add phpstan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ example coc-settings.json:
     "sh": "shellcheck",
     "elixir": ["mix_credo", "mix_credo_compile"],
     "eelixir": ["mix_credo", "mix_credo_compile"],
-    "php": "phpcs"
+    "php": "phpstan"
     ...
   },
   "diagnostic-languageserver.formatFiletypes": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -284,6 +284,24 @@ export const linters = {
       "message": "${Text} [${FromLinter}]",
     },
   },
+
+  "phpstan": {
+    "command": "./vendor/bin/phpstan",
+    "debounce": 100,
+    "rootPatterns": [ "composer.json", "composer.lock", "vendor", ".git" ],
+    "args": [ "analyze", "--error-format", "raw", "--no-progress", "%file" ],
+    "offsetLine": 0,
+    "offsetColumn": 0,
+    "sourceName": "phpstan",
+    "formatLines": 1,
+    "formatPattern": [
+      "^[^:]+:(\\d+):(.*)$",
+      {
+        "line": 1,
+        "message": 2,
+      },
+    ],
+  },
 }
 
 export const formatters = {


### PR DESCRIPTION
[PHPStan](https://github.com/phpstan/phpstan) was added.

I think `phpstan` has more users than `PHP_CodeSniffer`, so I have changed README.md.

I'm sorry, but if there is a problem, please put it back.

----

If you need to change the `--level` setting etc., put the `phpstan.neon` configuration file in the project

**e.g. phpstan.neon**

```
parameters:
  level: 5
  # more config...
```