### PR TITLE
Add psalm to Linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ example coc-settings.json:
     "sh": "shellcheck",
     "elixir": ["mix_credo", "mix_credo_compile"],
     "eelixir": ["mix_credo", "mix_credo_compile"],
-    "php": "phpstan"
+    "php": ["phpstan", "psalm"],
     ...
   },
   "diagnostic-languageserver.formatFiletypes": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -303,6 +303,31 @@ export const linters = {
     ],
   },
 
+  "psalm": {
+    "command": "./vendor/bin/psalm",
+    "debounce": 100,
+    "rootPatterns": ["composer.json", "composer.lock", "vendor", ".git"],
+    "args": ["--output-format=emacs", "--no-progress"],
+    "offsetLine": 0,
+    "offsetColumn": 0,
+    "sourceName": "psalm",
+    "formatLines": 1,
+    "formatPattern": [
+      "^[^:]+:(\\d):(\\d):(.*)\\s-\\s(.*)(\\r|\\n)*$",
+      {
+        "line": 1,
+        "column": 2,
+        "message": 4,
+        "security": 3
+      }
+    ],
+    "securities": {
+      "error": "error",
+      "warning": "warning"
+    },
+    "requiredFiles": ["psalm.xml"]
+  },
+
   "tidy": {
     "command": "tidy",
     "args": ["-e", "-q"],


### PR DESCRIPTION
## Description

Thanks for this "coc extension".

Added [Psalm](https://github.com/vimeo/psalm) linter for php.

I also updated the wiki of diagnostic-languageserver.
https://github.com/iamcco/diagnostic-languageserver/wiki/Linters#psalm

## Note

If there is no problem, please "publish to npm" after merge
