### PR TITLE
--other=update golangci-lint config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -272,18 +272,21 @@ export const linters = {
   },
 
   "golangci-lint": {
-    "command": "golangci-lint",
+    "command": "bash",
     "rootPatterns": [ ".git", "go.mod" ],
     "debounce": 100,
-    "args": [ "run", "--out-format", "json", "%file" ],
+    "args": [ "-c", "golangci-lint run --fast | grep %filename"],
     "sourceName": "golangci-lint",
-    "parseJson": {
-      "errorsRoot": "Issues",
-      "line": "Pos.Line",
-      "column": "Pos.Column",
-      "message": "${Text} [${FromLinter}]",
-    },
-  },
+    "formatPattern": [
+      "^[^:]+:(\\d+):(\\d+):\\s+(.*)$",
+      {
+        "line": 1,
+        "column": 2,
+        "message": [3]
+      }
+    ]
+  }
+
 
   "phpstan": {
     "command": "./vendor/bin/phpstan",


### PR DESCRIPTION
golangci-lint 新版，指定文件运行会报错

![image](https://user-images.githubusercontent.com/571878/78970737-9ec22800-7b3c-11ea-8644-ab954276eb9e.png)

搞了一下午搞不定，然后回退版本也不好使。

只能直接运行，然后简单过滤下文件名。