### PR TITLE
Prepare (postinstall) script calls build

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   },
   "scripts": {
     "watch": "tsc -w -p ./",
-    "build": "rm -rf ./out && webpack"
+    "build": "rm -rf ./out && webpack",
+    "prepare": "build"
   },
   "devDependencies": {
     "@types/node": "^12.0.0",


### PR DESCRIPTION
See https://github.com/neoclide/coc.nvim/blob/master/package.json#L16

Allow to install via vim-plug
```
Plug 'iamcco/coc-diagnostic', {'do': 'yarn install --frozen-lockfile'}
```

Fixes #31 
