### PR TITLE
Add "lua-format" formatter

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -397,5 +397,10 @@ export const formatters = {
     "rootPatterns": [".git"],
     "isStderr": false,
     "isStdout": true
+  },
+
+  "lua-format": {
+    "command": "lua-format",
+    "args": ["-i"]
   }
 }


### PR DESCRIPTION
## Description

Add lua-format setting.

I also updated the wiki of diagnostic-languageserver.

https://github.com/iamcco/diagnostic-languageserver/wiki/Formatters#lua-format

I'm sorry, but if there is a problem, please put it back.

## Download

Binary download is recommended to install `lua-format`.

https://github.com/Koihik/vscode-lua-format/tree/master/bin

## Note

If there is no problem, please "publish to npm" after merge