### PR TITLE
Add "shfmt" formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ example coc-settings.json:
   "diagnostic-languageserver.formatFiletypes": {
     "dart": "dartfmt",
     "elixir": "mix_format",
-    "eelixir": "mix_format"
+    "eelixir": "mix_format",
+    "lua": "lua-format",
     ...
   }
 }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ example coc-settings.json:
     "elixir": "mix_format",
     "eelixir": "mix_format",
     "lua": "lua-format",
+    "sh": "shfmt",
     ...
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -402,5 +402,9 @@ export const formatters = {
   "lua-format": {
     "command": "lua-format",
     "args": ["-i"]
+  },
+
+  "shfmt": {
+    "command": "shfmt"
   }
 }


### PR DESCRIPTION
## Description

Add shfmt setting.

I also updated the wiki of diagnostic-languageserver.

https://github.com/iamcco/diagnostic-languageserver/wiki/Formatters#shfmt

I'm sorry, but if there is a problem, please put it back.

## Tool

- GitHub
    - https://github.com/mvdan/sh
    - https://github.com/mvdan/sh#shfmt

- Homebrew
    - https://formulae.brew.sh/formula/shfmt

## Demo

![coc-diagnostic-shfmt-960](https://user-images.githubusercontent.com/188642/88458724-02dde180-cecb-11ea-8723-0b1a8a475fae.gif)

## Notes

If there is no problem, please "publish to npm" after merge

## Other

I've also added lua-format to the README.