### PR TITLE
Add "blade-formatter" formatter

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -407,9 +407,14 @@ export const formatters = {
   "shfmt": {
     "command": "shfmt"
   },
-  
+
   "tffmt": {
     "command": "terraform",
     "args": ["fmt", "-"]
+  },
+
+  "blade-formatter": {
+    "command": "blade-formatter",
+    "args": ["--stdin"]
   }
 }


### PR DESCRIPTION
### Description

Laravel (PHP Web Framework) has a template file called `blade`.

Add blade-formatter setting.

I also updated the wiki of diagnostic-languageserver.

https://github.com/iamcco/diagnostic-languageserver/wiki/Formatters#blade-formatter

I'm sorry, but if there is a problem, please put it back.

### Tool

- GitHub
    - https://github.com/shufo/blade-formatter
- npm
    - https://www.npmjs.com/package/blade-formatter

### Other (recommended plugin)

- **vim-blade**: blade syntax and filetype plugin
    - https://github.com/jwalton512/vim-blade

### DEMO

![coc-diagnostic-blade-formatter-1200](https://user-images.githubusercontent.com/188642/89741291-f8c30200-daca-11ea-9fe3-aa7993e6f3f8.gif)
