### PR TITLE
Add blade-formatter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ example coc-settings.json:
     "eelixir": "mix_format",
     "lua": "lua-format",
     "sh": "shfmt",
+    "blade": "blade-formatter",
     ...
   }
 }


### PR DESCRIPTION
I forgot to add it to the README in this [PR](https://github.com/iamcco/coc-diagnostic/commit/8891a611536d3f420909256e0a62aed1e059b495), so I've added it now.