### PR TITLE
Change golangci-lint config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -275,9 +275,11 @@ export const linters = {
     "command": "golangci-lint",
     "rootPatterns": [ ".git", "go.mod" ],
     "debounce": 100,
-    "args": [ "run", "--out-format", "json", "%file" ],
+    "args": [ "run", "--out-format", "json" ],
     "sourceName": "golangci-lint",
     "parseJson": {
+      "sourceName": "Pos.Filename",
+      "sourceNameFilter": true,
       "errorsRoot": "Issues",
       "line": "Pos.Line",
       "column": "Pos.Column",


### PR DESCRIPTION
Hi, this changes the default config for the golangci-linter based on the changes implemented in https://github.com/iamcco/diagnostic-languageserver/commit/03a713e1ac762b9d1bf786a348adefcd666d1ce8.

Removes `%file` because this linter does not work on a single file when
that file uses code defined in other files. Add filtering on `sourceName` to
only display diagnostics from the current file.