### PR TITLE
Add fish -n linter

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -410,7 +410,24 @@ export const linters = {
       "warning": "warning"
     },
     "sourceName": "yamllint"
+  },
+
+  "fish": {
+    "command": "fish",
+    "args": ["-n", "%file"],
+    "isStdout": false,
+    "isStderr": true,
+    "sourceName": "fish",
+    "formatLines": 1,
+    "formatPattern": [
+      "^.*\\(line (\\d+)\\): (.*)$",
+      {
+        "line": 1,
+        "message": 2
+      }
+    ]
   }
+
 }
 
 export const formatters = {


### PR DESCRIPTION
Please add linter config for [fish](https://fishshell.com/) `-n` option.
It outputs only one finding at a time in following format:
```
~/in/lfcd.fish (line 13): Unexpected ')' for unopened parenthesis
set )
    ^
<W> fish: Error while reading file /home/hajdamak/in/lfcd.fish
```
I am only taking into account first line. Should others be taken also? If yes how?
Last line is unimportant. There might be different number of lines between the first and the last.