### PR TITLE
Add various python formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ example coc-settings.json:
     "dart": "dartfmt",
     "elixir": "mix_format",
     "eelixir": "mix_format",
+    "python": ["black", "isort"],
     "lua": "lua-format",
     "sh": "shfmt",
     "blade": "blade-formatter",

--- a/src/config.ts
+++ b/src/config.ts
@@ -667,5 +667,26 @@ export const formatters = {
     "command": "./node_modules/.bin/xo",
     "args": ["--fix", "--stdin", "--stdin-filename", "%filepath"],
     "rootPatterns": ["package.json"]
+  },
+
+  "black": {
+    "command": "black",
+    "args": ["--quiet", "-"]
+  },
+
+  "autopep8": {
+    "command": "autopep8",
+    "args": ["-"]
+  },
+
+  "yapf": {
+    "command": "yapf",
+    "args": ["--quiet"]
+  },
+
+  "isort": {
+    "command": "isort",
+    "args": ["--quiet", "-"]
   }
+
 }


### PR DESCRIPTION
## Tools

- **black**
    - https://github.com/psf/black
    - https://black.readthedocs.io/en/stable/ 
- **autopep8**
    - https://github.com/hhatto/autopep8
- **yapf**
    - https://github.com/google/yapf
- **isort**
    - https://github.com/PyCQA/isort
    - https://pycqa.github.io/isort/

## Capture (DEMO)

(Use `black` + `isort`)

![coc-dls-black-isort](https://user-images.githubusercontent.com/188642/104126376-85862a80-539f-11eb-9791-37dc0221eb72.gif)

## Misc

[diagnostic-languageserver's wiki](https://github.com/iamcco/diagnostic-languageserver/wiki/Formatters) has been updated.
