### PR TITLE
fix markdownlint config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -120,11 +120,11 @@ export const linters = {
     "sourceName": "markdownlint",
     "formatLines": 1,
     "formatPattern": [
-      "^.*?:\\s+(\\d+):\\s+(.*)(\\r|\\n)*$",
+      "^.*?:\\s?(\\d+)(:(\\d+)?)?\\s(MD\\d{3}\\/[A-Za-z0-9-/]+)\\s(.*)$",
       {
         "line": 1,
-        "column": -1,
-        "message": 2
+        "column": 3,
+        "message": [4]
       }
     ]
   },


### PR DESCRIPTION
## Description

It's about markdownlint in this [issue](https://github.com/iamcco/coc-diagnostic/issues/68).

There seemed to be a mistake in the current config of `markdownlint`.

I changed the config based on [ale's markdownlint](https://github.com/dense-analysis/ale/blob/master/autoload/ale/handlers/markdownlint.vim#L5).

[diagnostic-languageserver's wiki](https://github.com/iamcco/diagnostic-languageserver/wiki/Linters) has been updated.

## Capture after change

<img width="1255" alt="fix-markdownlint-setting" src="https://user-images.githubusercontent.com/188642/104202086-d19fa080-546d-11eb-8a67-69e15386a06f.png">
