### PR TITLE
Fix the psalm format pattern

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -331,7 +331,7 @@ export const linters = {
     "sourceName": "psalm",
     "formatLines": 1,
     "formatPattern": [
-      "^[^:]+:(\\d):(\\d):(.*)\\s-\\s(.*)(\\r|\\n)*$",
+      "^[^:]+:(\\d+):(\\d+):(.*)\\s-\\s(.*)(\\r|\\n)*$",
       {
         "line": 1,
         "column": 2,


### PR DESCRIPTION
The current regular expression only matches when the error row and column are single digits.