### PR TITLE
Add 500 ms debounce to Pylint to reduce CPU usage

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -472,6 +472,7 @@ export const linters = {
   "pylint": {
     "sourceName": "pylint",
     "command": "pylint",
+    "debounce": 500,
     "args": [
       "--output-format",
       "text",


### PR DESCRIPTION
Pylint can be very CPU intensive depending on how its configured. It's not uncommon to get fans when making rapid changes.

Fixes GH-87