### PR TITLE
fix(config): set the filename for shfmt

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -683,7 +683,8 @@ export const formatters = {
   },
 
   "shfmt": {
-    "command": "shfmt"
+    "command": "shfmt",
+    "args": ["-filename", "%filepath"]
   },
 
   "tffmt": {


### PR DESCRIPTION
This tells shfmt what the filename was, which allows its parsing of the
.editorconfig file to work properly.

Refs: https://github.com/mvdan/sh/issues/577