### PR TITLE
luacheck: Add "--filename=%filepath" to args list

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -667,6 +667,8 @@ export const linters = {
       "plain",
       "--codes",
       "--ranges",
+      "--filename",
+      "%filepath",
       "-"
     ],
     "sourceName": "luacheck",


### PR DESCRIPTION
Without this `luacheck` will interpret all files as if they are named `stdin` instead of their actual name. This causes issues with configuration like `exclude_files` that works off the filepath.

So something like this doesn't work as expected since it will be matched against "stdin" instead of "foo/bar/baz.lua".

```lua
exclude_files = {
  "foo/bar/baz.lua"
}
```