### PR TITLE
Avoid psalm to lint all files instead of only current one

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -325,7 +325,7 @@ export const linters = {
     "command": "./vendor/bin/psalm",
     "debounce": 100,
     "rootPatterns": ["composer.json", "composer.lock", "vendor", ".git"],
-    "args": ["--output-format=emacs", "--no-progress"],
+    "args": ["--output-format=emacs", "--no-progress", "%file"],
     "offsetLine": 0,
     "offsetColumn": 0,
     "sourceName": "psalm",


### PR DESCRIPTION
Without this change, Psalm report all project errors in one file...