### PR TITLE
shellcheck: Use json1 format for correct column reporting

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,11 +36,12 @@ export const linters = {
     "debounce": 100,
     "args": [
       "--format",
-      "json",
+      "json1",
       "-"
     ],
     "sourceName": "shellcheck",
     "parseJson": {
+      "errorsRoot": "comments",
       "line": "line",
       "column": "column",
       "endLine": "endLine",


### PR DESCRIPTION
The currently used `json` format counts hard tabs as 8 columns, when
reporting column offsets. This leads to misaligned error display.

Example output:
<img width="690" alt="screenshot of misaligned error display" src="https://user-images.githubusercontent.com/47396753/125173282-2aef4f00-e1c7-11eb-8825-f448d10d369e.png">

The `json1` format counts tabs as 1 column. This format outputs an
object with the errors array under the "comments" key.

The new format was added in shellcheck v0.7.0:
https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v070---2019-07-28

About the output format:
https://github.com/koalaman/shellcheck/wiki/Integration#json-output