### PR TITLE
fix(config): fix regex pattern of cpplint

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -544,7 +544,7 @@ export const linters = {
     "offsetLine": 0,
     "offsetColumn": 0,
     "formatPattern": [
-      "^[^:]+:(\\d+):(\\d+)?\\s+([^:]+?)\\s\\[(\\d)\\]$",
+      "^[^:]+:(\\d+):(\\d+)?\\s+(.+?)\\s\\[(\\d)\\]$",
       {
         "line": 1,
         "column": 2,


### PR DESCRIPTION
The error messages of `cpplint` may contain colons. For example:

``` js
const pattern = new RegExp("^[^:]+:(\\d+):(\\d+)?\\s+(.+?)\\s\\[(\\d)\\]$");
const match = pattern.exec(
  "carrot/include/main.h:1:  #ifndef header guard has wrong style, " +
  "please use: FOO_INCLUDE_MAIN_H_  [build/header_guard] [5]");

import('assert').then((assert) => {
    assert.equal(match[1], "1");
    assert.equal(
      match[3],
      "#ifndef header guard has wrong style, " +
      "please use: FOO_INCLUDE_MAIN_H_  [build/header_guard]"
    );
    assert.equal(match[4], "5");
});
```