### PR TITLE
fix(eslint): use .eslintrc.* and package.json as root patterns

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,12 @@ export const linters = {
   "eslint": {
     "command": "./node_modules/.bin/eslint",  // this will find local eslint first, if local eslint not found, it
     "rootPatterns": [
-      ".git"
+      ".eslintrc.js",
+      ".eslintrc.cjs",
+      ".eslintrc.yaml",
+      ".eslintrc.yml",
+      ".eslintrc.json",
+      "package.json"
     ],
     "debounce": 100,
     "args": [


### PR DESCRIPTION
ESLint refuses to run without a config file. So use the various config file formats as root patterns instead of `.git` to support the scenario where the config files aren't located in the root of a Git repository (e.g. a monorepo).

https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats