### PR TITLE
fix: [Cppcheck] gutter signs disappear when nofile case

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -585,7 +585,7 @@ export const linters = {
     "offsetLine": 0,
     "offsetColumn": 0,
     "formatPattern": [
-      "^[^:]+:(\\d+):(\\d+):\\s+([^:]+):\\s+(.+?)$",
+      "^[^:]+:([1-9]\\d*):(\\d+):\\s+([^:]+):\\s+(.+?)$",
       {
         "line": 1,
         "column": 2,


### PR DESCRIPTION
Cppcheck uses the following format to provide file-irrelevant warning/information, for example:
```
nofile:0:0: information: Unmatched suppression: missingIncludeSystem [unmatchedSuppression]
```
This will cause the gutter signs to disappear, so a simple workaround is to only match line numbers greater than 0.