### PR TITLE
Revert "Prefer space indentation on shfmt"

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -839,7 +839,7 @@ export const formatters = {
 
   "shfmt": {
     "command": "shfmt",
-    "args": ["-i", "2", "-filename", "%filepath"]
+    "args": ["-filename", "%filepath"]
   },
 
   "tffmt": {


### PR DESCRIPTION
This reverts #119.

See https://github.com/iamcco/coc-diagnostic/pull/119#issuecomment-1033555114 for more details, but the tl;dr is that setting a this flag causes shfmt to ignore EditorConfig settings.

> If any parser or printer flags are given to the tool, no EditorConfig files will be used.