### PR TITLE
Fix languagetool's args

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -173,7 +173,7 @@ export const linters = {
   "languagetool": {
     "command": "languagetool",
     "debounce": 200,
-    "args": ["-"],
+    "args": ["%file"],
     "offsetLine": 0,
     "offsetColumn": 0,
     "sourceName": "languagetool",


### PR DESCRIPTION
Now languagetool don't support `languagetool -`, user must tell it file name.

As following, a file named `-` is not found.

```sh
❯ languagetool -
WARN: no common words file defined for Japanese - this language might not be correctly auto-detected
WARN: no common words file defined for Khmer - this language might not be correctly auto-detected
java.io.FileNotFoundException: - (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
        at org.languagetool.gui.Main.loadFile(Main.java:216)
        at org.languagetool.gui.Main.access$2100(Main.java:144)
        at org.languagetool.gui.Main$7.run(Main.java:1204)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```
