### PR TITLE
feat: support shfmt

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,26 @@ export const linters = {
     }
   },
 
+  "shfmt": {
+    "command": "shfmt",
+    "args": ["-w", "%file"],
+    "isStdout": false,
+    "isStderr": true,
+    "debounce": 100,
+    "offsetLine": 0,
+    "offsetColumn": 0,
+    "sourceName": "shfmt",
+    "formatLines": 1,
+    "formatPattern": [
+      ".*?:(\\d+):(\\d+): (.*)",
+      {
+        "line": 1,
+        "column": 2,
+        "message": 3
+      }
+    ]
+  },
+
   "syntest": {
     "command": "syntest",
     "args": ["%file", "."],


### PR DESCRIPTION
`shfmt -w` can be a linter

![screen-2023-01-22-01-33-47](https://user-images.githubusercontent.com/32936898/213879874-73c6e5c8-43ce-46fd-bdeb-d8bef9a13ecd.jpg)